### PR TITLE
Include the Dash UI image in the EC2

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -37,3 +37,10 @@ services:
     container_name: frontend
     ports:
       - 3000
+
+  dashui:
+    image: public.ecr.aws/j8z6n5u1/ohos-dash-ui
+    hostname: dashui
+    container_name: dashui
+    ports:
+      - 8050:8050


### PR DESCRIPTION
Dash image included in the dockercompose, so it gets bought up with restart.sh. 
It's intentionally not included in the Kong config in restart.sh, as we don't need it to be visible publically to the end user - it only needs to be visible locally, so Wagtail can see it and iframe it.